### PR TITLE
Add example rank system plugin

### DIFF
--- a/rank_system/pyproject.toml
+++ b/rank_system/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "endstone-rank-system"
+version = "0.1.0"
+description = "A basic rank system plugin example"
+
+[project.entry-points."endstone.plugins"]
+rank_system = "endstone_rank_system:RankSystem"

--- a/rank_system/src/endstone_rank_system/__init__.py
+++ b/rank_system/src/endstone_rank_system/__init__.py
@@ -1,0 +1,3 @@
+from .rank_system import RankSystem
+
+__all__ = ["RankSystem"]

--- a/rank_system/src/endstone_rank_system/rank_system.py
+++ b/rank_system/src/endstone_rank_system/rank_system.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from endstone.event import (
+    ActorDeathEvent,
+    BlockBreakEvent,
+    PlayerDeathEvent,
+    PlayerJoinEvent,
+    event_handler,
+)
+from endstone.form import ActionForm
+from endstone.plugin import Plugin
+from endstone.scoreboard import Criteria, DisplaySlot
+
+
+class RankSystem(Plugin):
+    api_version = "0.5"
+    name = "rank-system"
+
+    commands = {
+        "rank": {
+            "description": "Open the rank selection UI.",
+            "usages": ["/rank"],
+            "permissions": ["rank_system.command.rank"],
+        }
+    }
+
+    permissions = {
+        "rank_system.command.rank": {
+            "description": "Allow using /rank to choose rank display.",
+            "default": True,
+        }
+    }
+
+    ORES = {
+        "minecraft:coal_ore",
+        "minecraft:iron_ore",
+        "minecraft:copper_ore",
+        "minecraft:gold_ore",
+        "minecraft:diamond_ore",
+        "minecraft:emerald_ore",
+        "minecraft:redstone_ore",
+        "minecraft:lapis_ore",
+        "minecraft:nether_gold_ore",
+        "minecraft:ancient_debris",
+    }
+
+    def on_enable(self) -> None:
+        sb = self.server.scoreboard
+        for obj, display in [
+            ("mob_kills", "Mob Kills"),
+            ("player_kills", "Player Kills"),
+            ("ores_mined", "Ores Mined"),
+        ]:
+            if not sb.get_objective(obj):
+                sb.add_objective(obj, Criteria.Type.DUMMY, display)
+
+        self.register_events(self)
+
+    # Event handlers
+    @event_handler
+    def on_actor_death(self, event: ActorDeathEvent) -> None:
+        killer = event.damage_source.actor
+        if killer and killer.is_player and not isinstance(event, PlayerDeathEvent):
+            obj = self.server.scoreboard.get_objective("mob_kills")
+            score = obj.get_score(killer)
+            score.value = score.value + 1
+
+    @event_handler
+    def on_player_death(self, event: PlayerDeathEvent) -> None:
+        killer = event.damage_source.actor
+        if killer and killer.is_player:
+            obj = self.server.scoreboard.get_objective("player_kills")
+            score = obj.get_score(killer)
+            score.value = score.value + 1
+
+    @event_handler
+    def on_block_break(self, event: BlockBreakEvent) -> None:
+        if event.block.type in self.ORES:
+            obj = self.server.scoreboard.get_objective("ores_mined")
+            score = obj.get_score(event.player)
+            score.value = score.value + 1
+
+    @event_handler
+    def on_player_join(self, event: PlayerJoinEvent) -> None:
+        # Display mob_kills by default
+        obj = self.server.scoreboard.get_objective("mob_kills")
+        obj.set_display(DisplaySlot.SIDEBAR)
+        event.player.scoreboard = self.server.scoreboard
+
+    def on_command(self, sender, command, args):
+        if command.name != "rank" or not sender.is_player:
+            return False
+
+        player = sender
+        sb = self.server.scoreboard
+        form = ActionForm("Select Rank")
+        form.add_button("Mob Kills")
+        form.add_button("Player Kills")
+        form.add_button("Ores Mined")
+
+        def handle(p, index):
+            obj_name = ["mob_kills", "player_kills", "ores_mined"][index]
+            obj = sb.get_objective(obj_name)
+            sb.clear_slot(DisplaySlot.SIDEBAR)
+            obj.set_display(DisplaySlot.SIDEBAR)
+            p.scoreboard = sb
+
+        form.on_submit = handle
+        form.show(player)
+        return True

--- a/rank_system/src/endstone_rank_system/rank_system.py
+++ b/rank_system/src/endstone_rank_system/rank_system.py
@@ -9,7 +9,7 @@ from endstone.event import (
 )
 from endstone.form import ActionForm
 from endstone.plugin import Plugin
-from endstone.scoreboard import Criteria, DisplaySlot
+from endstone.scoreboard import Criteria
 
 
 class RankSystem(Plugin):
@@ -31,6 +31,24 @@ class RankSystem(Plugin):
         }
     }
 
+    RANKS = {
+        "mob_kills": [
+            (0, "Hunter"),
+            (10, "Slayer"),
+            (50, "Beastmaster"),
+        ],
+        "player_kills": [
+            (0, "Fighter"),
+            (10, "Warrior"),
+            (30, "Champion"),
+        ],
+        "ores_mined": [
+            (0, "Miner"),
+            (50, "Excavator"),
+            (150, "Prospector"),
+        ],
+    }
+
     ORES = {
         "minecraft:coal_ore",
         "minecraft:iron_ore",
@@ -44,6 +62,10 @@ class RankSystem(Plugin):
         "minecraft:ancient_debris",
     }
 
+    def __init__(self):
+        super().__init__()
+        self._selected: dict[str, str] = {}
+
     def on_enable(self) -> None:
         sb = self.server.scoreboard
         for obj, display in [
@@ -56,6 +78,25 @@ class RankSystem(Plugin):
 
         self.register_events(self)
 
+    def _get_rank_name(self, obj_name: str, value: int) -> str:
+        tiers = self.RANKS.get(obj_name, [])
+        rank = tiers[0][1] if tiers else ""
+        for threshold, name in tiers:
+            if value >= threshold:
+                rank = name
+            else:
+                break
+        return rank
+
+    def _update_player_rank(self, player) -> None:
+        stat = self._selected.get(player.unique_id)
+        if not stat:
+            return
+        obj = self.server.scoreboard.get_objective(stat)
+        score = obj.get_score(player)
+        rank_name = self._get_rank_name(stat, score.value)
+        player.name_tag = f"[{rank_name}] {player.name}"
+
     # Event handlers
     @event_handler
     def on_actor_death(self, event: ActorDeathEvent) -> None:
@@ -64,6 +105,8 @@ class RankSystem(Plugin):
             obj = self.server.scoreboard.get_objective("mob_kills")
             score = obj.get_score(killer)
             score.value = score.value + 1
+            if self._selected.get(killer.unique_id) == "mob_kills":
+                self._update_player_rank(killer)
 
     @event_handler
     def on_player_death(self, event: PlayerDeathEvent) -> None:
@@ -72,6 +115,8 @@ class RankSystem(Plugin):
             obj = self.server.scoreboard.get_objective("player_kills")
             score = obj.get_score(killer)
             score.value = score.value + 1
+            if self._selected.get(killer.unique_id) == "player_kills":
+                self._update_player_rank(killer)
 
     @event_handler
     def on_block_break(self, event: BlockBreakEvent) -> None:
@@ -79,13 +124,16 @@ class RankSystem(Plugin):
             obj = self.server.scoreboard.get_objective("ores_mined")
             score = obj.get_score(event.player)
             score.value = score.value + 1
+            if self._selected.get(event.player.unique_id) == "ores_mined":
+                self._update_player_rank(event.player)
 
     @event_handler
     def on_player_join(self, event: PlayerJoinEvent) -> None:
         # Display mob_kills by default
         obj = self.server.scoreboard.get_objective("mob_kills")
-        obj.set_display(DisplaySlot.SIDEBAR)
         event.player.scoreboard = self.server.scoreboard
+        self._selected[event.player.unique_id] = "mob_kills"
+        self._update_player_rank(event.player)
 
     def on_command(self, sender, command, args):
         if command.name != "rank" or not sender.is_player:
@@ -100,10 +148,9 @@ class RankSystem(Plugin):
 
         def handle(p, index):
             obj_name = ["mob_kills", "player_kills", "ores_mined"][index]
-            obj = sb.get_objective(obj_name)
-            sb.clear_slot(DisplaySlot.SIDEBAR)
-            obj.set_display(DisplaySlot.SIDEBAR)
+            self._selected[p.unique_id] = obj_name
             p.scoreboard = sb
+            self._update_player_rank(p)
 
         form.on_submit = handle
         form.show(player)


### PR DESCRIPTION
## Summary
- add a new `endstone-rank-system` plugin that tracks mob kills, player kills and mined ores
- provide `/rank` command that opens a UI for selecting which rank to display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'endstone')*

------
https://chatgpt.com/codex/tasks/task_b_6842fc9c09e48332967b38dfa2067e67